### PR TITLE
Make icon bigger on some terminal by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ require('render-markdown').setup({
     -- modes will be uneffected by this plugin
     render_modes = { 'n', 'c' },
     -- Characters that will replace the # at the start of markdown headings
-    headings = { '󰲡', '󰲣', '󰲥', '󰲧', '󰲩', '󰲫' },
+    headings = { '󰲡 ', '󰲣 ', '󰲥 ', '󰲧 ', '󰲩 ', '󰲫 ' },
     -- Character to use for the bullet point in lists
-    bullet = '○',
+    bullet = '○ ',
     highlights = {
         heading = {
             -- Used for rendering heading line backgrounds

--- a/lua/render-markdown/init.lua
+++ b/lua/render-markdown/init.lua
@@ -54,8 +54,8 @@ function M.setup(opts)
         ]],
         file_types = { 'markdown' },
         render_modes = { 'n', 'c' },
-        headings = { '󰲡', '󰲣', '󰲥', '󰲧', '󰲩', '󰲫' },
-        bullet = '○',
+        headings = { '󰲡 ', '󰲣 ', '󰲥 ', '󰲧 ', '󰲩 ', '󰲫 ' },
+        bullet = '○ ',
         highlights = {
             heading = {
                 backgrounds = { 'DiffAdd', 'DiffChange', 'DiffDelete' },


### PR DESCRIPTION
On some terminal, unicode icons will span 2 cells if the icon is followed by a white space.
This make the icons looks bigger and is comparable to text.

This PR changes the default icons with an explicit space in between. It does not make the rendered text any longer, just make the icons look bigger on supported terminal.
Before/After:
<img width="322" alt="Screenshot 2024-03-24 at 15 58 35" src="https://github.com/MeanderingProgrammer/markdown.nvim/assets/12573521/d593ba2f-fe23-4073-a68e-d5b014f5a7d8">
<img width="301" alt="Screenshot 2024-03-24 at 15 58 22" src="https://github.com/MeanderingProgrammer/markdown.nvim/assets/12573521/f6a65be3-be40-450d-b8d9-7461d9f624c7">
