### PR TITLE
Use better default callout icons

### DIFF
--- a/lua/render-markdown/init.lua
+++ b/lua/render-markdown/init.lua
@@ -139,11 +139,11 @@ M.default_config = {
     quote = '┃',
     -- Symbol / text to use for different callouts
     callout = {
-        note = '  Note',
-        tip = '  Tip',
-        important = '󰅾  Important',
-        warning = '  Warning',
-        caution = '󰳦  Caution',
+        note = '󰋽 Note',
+        tip = '󰌶 Tip',
+        important = '󰅾 Important',
+        warning = '󰀪 Warning',
+        caution = '󰳦 Caution',
     },
     -- Window options to use that change between rendered and raw view
     win_options = {

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -424,7 +424,7 @@ async_tests.describe('init', function()
             {
                 row = { 2, 2 },
                 col = { 2, 9 },
-                virt_text = { { '  Note', 'DiagnosticInfo' } },
+                virt_text = { { '󰋽 Note', 'DiagnosticInfo' } },
                 virt_text_pos = 'overlay',
             },
             -- Quote continued
@@ -458,7 +458,7 @@ async_tests.describe('init', function()
             {
                 row = { 7, 7 },
                 col = { 2, 8 },
-                virt_text = { { '  Tip', 'DiagnosticOk' } },
+                virt_text = { { '󰌶 Tip', 'DiagnosticOk' } },
                 virt_text_pos = 'overlay',
             },
             -- Quote continued
@@ -492,7 +492,7 @@ async_tests.describe('init', function()
             {
                 row = { 12, 12 },
                 col = { 2, 14 },
-                virt_text = { { '󰅾  Important', 'DiagnosticHint' } },
+                virt_text = { { '󰅾 Important', 'DiagnosticHint' } },
                 virt_text_pos = 'overlay',
             },
             -- Quote continued
@@ -526,7 +526,7 @@ async_tests.describe('init', function()
             {
                 row = { 17, 17 },
                 col = { 2, 12 },
-                virt_text = { { '  Warning', 'DiagnosticWarn' } },
+                virt_text = { { '󰀪 Warning', 'DiagnosticWarn' } },
                 virt_text_pos = 'overlay',
             },
             -- Quote continued
@@ -560,7 +560,7 @@ async_tests.describe('init', function()
             {
                 row = { 22, 22 },
                 col = { 2, 12 },
-                virt_text = { { '󰳦  Caution', 'DiagnosticError' } },
+                virt_text = { { '󰳦 Caution', 'DiagnosticError' } },
                 virt_text_pos = 'overlay',
             },
             -- Quote continued


### PR DESCRIPTION
In my opinion, the current default callout icons look a bit out of place when compared to e.g. the default heading icons. The note icon looks a bit too big, and the gap between the icons and text is also bigger (a lot bigger for the Tip callout).

This changes all the callout icons to use the `nf-md-*_outline` icons (https://www.nerdfonts.com/cheat-sheet), which are already being used for the Important and Warning callouts. Because they are smaller icons, the gap between the icon and the text can be reduced to generally be the same as for the headings.

An alternative is to use the same icons GitHub uses - the `nf-oct-*` icons. These are larger icons, so the gap between the icon and text can't be made smaller without losing the gap entirely for all but the Tip callout. The very large gap for the Tip callout is the main reason I prefer the `nf-md-*_outline` icons instead.

This is all obviously personal preference, so I completely understand if you don't agree - feel free to close this if you'd like.

## Before

|  | Text | Icon class |
|---|---|---|
| Note | `  Note` | nf-oct-info |
| Tip | `  Tip` | nf-oct-light_bulb |
| Important | `󰅾  Important` | nf-md-comment_alert_outline |
| Warning | `  Warning` | nf-cod-warning |
| Caution | `󰳦  Caution` | nf-md-alert_octagon_outline |

![before](https://github.com/MeanderingProgrammer/markdown.nvim/assets/49614525/00a2ac5a-00c9-49fa-8104-4d73a78ad3ef)

## After

|  | Text | Icon class |
|---|---|---|
| Note | `󰋽 Note` | nf-md-information_outline |
| Tip | `󰌶 Tip` | nf-md-lightbulb_outline |
| Important | `󰅾 Important` | nf-md-comment_alert_outline |
| Warning | `󰀪 Warning` | nf-md-alert_outline |
| Caution | `󰳦 Caution` | nf-md-alert_octagon_outline |

![after](https://github.com/MeanderingProgrammer/markdown.nvim/assets/49614525/c0c5f992-965f-47be-b77f-0cf27d5b5ac9)

## Alternative

|  | Text | Icon class |
|---|---|---|
| Note | `  Note` | nf-oct-info |
| Tip | `  Tip` | nf-oct-light_bulb |
| Important | `  Important` | nf-oct-report |
| Warning | `  Warning` | nf-oct-alert |
| Caution | `  Caution` | nf-oct-stop |

![alt](https://github.com/MeanderingProgrammer/markdown.nvim/assets/49614525/3d5e835a-516a-499c-bbb2-6a9db338a998)

