### PR TITLE
feat: support luarocks/rocks.nvim

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,42 @@
+name: Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+  pull_request: # Tests packaging on PR
+  workflow_dispatch:
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to get the tags
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+
+      - name: Install C/C++ Compiler
+        uses: rlalik/setup-cpp-compiler@master
+        with:
+          compiler: clang-latest
+
+      - name: Install tree-sitter CLI
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: tree-sitter-cli
+
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v7
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            tree-sitter-markdown
+            tree-sitter-latex
+            nvim-web-devicons

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Plugin to improve viewing Markdown files in Neovim
 }
 ```
 
+## rocks.nvim
+
+```vimscript
+:Rocks install markdown.nvim
+```
+
 ## packer.nvim
 
 ```lua


### PR DESCRIPTION
Hey :wave: 

### Summary

This PR is part of a push to get neovim plugins on [luarocks.org](https://luarocks.org/labels/neovim).

See also:

- [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.
- [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html).

With luarocks/rocks.nvim, it is [the plugin authors' responsibility to declare dependencies and build instructions - not the user's](https://github.com/nvim-neorocks/rocks.nvim?tab=readme-ov-file#grey_question-why-rocksnvim).
Installing this plugin becomes as simple as `:Rocks install markdown.nvim`.

### Things done:

- Add a workflow that publishes tags to luarocks.org when a tag or release is pushed.

See also: [this guide](https://github.com/nvim-neorocks/sample-luarocks-plugin)

### Notes:

> [!IMPORTANT]
> 
> - **For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)**.

- Tagged releases are installed locally and then published to luarocks.org.
  - If you push tags from a local checkout, the workflow is triggered automatically.
  - If you use GitHub releases to create tags, you may need to [add a PA token](https://github.com/nvim-neorocks/sample-luarocks-plugin?tab=readme-ov-file#generating-a-pat-personal-access-token) for the workflow to be triggered automatically.
- Due to a shortcoming in luarocks.org (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the luarocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.