### PR TITLE
docs: better install instructions for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Plugin to improve viewing Markdown files in Neovim
 ```lua
 {
     'MeanderingProgrammer/markdown.nvim',
-    ft = "markdown",
     main = "render-markdown",
     opts = {},
     name = 'render-markdown', -- Only needed if you have another plugin named markdown.nvim

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Plugin to improve viewing Markdown files in Neovim
     dependencies = { 'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.nvim' }, -- if you use the mini.nvim suite
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.icons' }, -- if you use standalone mini plugins
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'nvim-tree/nvim-web-devicons' }, -- if you prefer nvim-web-devicons
-}
+},
 ```
 
 ## packer.nvim

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Plugin to improve viewing Markdown files in Neovim
 ```lua
 {
     'MeanderingProgrammer/markdown.nvim',
+    ft = "markdown",
+    main = "render-markdown",
+    opts = {},
     name = 'render-markdown', -- Only needed if you have another plugin named markdown.nvim
     dependencies = { 'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.nvim' }, -- if you use the mini.nvim suite
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'echasnovski/mini.icons' }, -- if you use standalone mini plugins
     -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'nvim-tree/nvim-web-devicons' }, -- if you prefer nvim-web-devicons
-    config = function()
-        require('render-markdown').setup({})
-    end,
 }
 ```
 


### PR DESCRIPTION
- `ft` ensures the plugin is only loaded in markdown files
- `main` defines the module name used in the `setup` call, we can use `opts` instead of `config` (cleaner & preferred method of configuring plugins in lazy.nvim)
- consequently, we are able to replace `config` with `opts`. reference: https://lazy.folke.io/spec#spec-setup
- also added the missing trailing comma for lazy plugin specs