### PR TITLE
LaTeX compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ require('render-markdown').setup({
         converter = 'latex2text',
         -- Highlight for LaTeX blocks
         highlight = 'RenderMarkdownMath',
+        -- Amount of empty lines above and below LaTeX blocks
+        lines_above = 0,
+        lines_below = 0,
     },
     heading = {
         -- Turn on / off heading icon & background rendering

--- a/doc/render-markdown.txt
+++ b/doc/render-markdown.txt
@@ -222,6 +222,9 @@ Full Default Configuration ~
             converter = 'latex2text',
             -- Highlight for LaTeX blocks
             highlight = 'RenderMarkdownMath',
+            -- Amount of empty lines above and below LaTeX blocks
+            lines_above = 0,
+            lines_below = 0,
         },
         heading = {
             -- Turn on / off heading icon & background rendering

--- a/lua/render-markdown/handler/latex.lua
+++ b/lua/render-markdown/handler/latex.lua
@@ -25,6 +25,14 @@ M.parse = function(root, buf)
         logger.debug('Executable not found: ' .. latex.converter)
         return {}
     end
+    if latex.lines_above < 0 then
+        logger.debug('lines_above must be greater than or equal to 0')
+        return {}
+    end
+    if latex.lines_below < 0 then
+        logger.debug('lines_below must be greater than or equal to 0')
+        return {}
+    end
 
     local info = ts.info(root, buf)
     logger.debug_node_info('latex', info)
@@ -34,6 +42,15 @@ M.parse = function(root, buf)
         local raw_expression = vim.fn.system(latex.converter, info.text)
         expressions = vim.split(raw_expression, '\n')
         table.remove(expressions, nil)
+
+        for i=1, latex.lines_above do
+            table.insert(expressions, 1, '')
+        end
+
+        for i=1, latex.lines_below do
+            table.insert(expressions, '')
+        end
+
         cache.expressions[info.text] = expressions
     end
 

--- a/lua/render-markdown/handler/latex.lua
+++ b/lua/render-markdown/handler/latex.lua
@@ -33,6 +33,7 @@ M.parse = function(root, buf)
     if expressions == nil then
         local raw_expression = vim.fn.system(latex.converter, info.text)
         expressions = vim.split(raw_expression, '\n')
+        table.remove(expressions, nil)
         cache.expressions[info.text] = expressions
     end
 

--- a/lua/render-markdown/handler/latex.lua
+++ b/lua/render-markdown/handler/latex.lua
@@ -32,8 +32,7 @@ M.parse = function(root, buf)
     local expressions = cache.expressions[info.text]
     if expressions == nil then
         local raw_expression = vim.fn.system(latex.converter, info.text)
-        local parsed_expressions = vim.split(vim.trim(raw_expression), '\n', { plain = true })
-        expressions = vim.tbl_map(vim.trim, parsed_expressions)
+        expressions = vim.split(raw_expression, '\n')
         cache.expressions[info.text] = expressions
     end
 

--- a/lua/render-markdown/init.lua
+++ b/lua/render-markdown/init.lua
@@ -87,6 +87,8 @@ local M = {}
 ---@field public enabled? boolean
 ---@field public converter? string
 ---@field public highlight? string
+---@field public lines_above? integer
+---@field public lines_below? integer
 
 ---@class render.md.UserAntiConceal
 ---@field public enabled? boolean
@@ -196,6 +198,9 @@ M.default_config = {
         converter = 'latex2text',
         -- Highlight for LaTeX blocks
         highlight = 'RenderMarkdownMath',
+        -- Amount of empty lines above and below LaTeX blocks
+        lines_above = 0,
+        lines_below = 0,
     },
     heading = {
         -- Turn on / off heading icon & background rendering

--- a/lua/render-markdown/state.lua
+++ b/lua/render-markdown/state.lua
@@ -102,6 +102,8 @@ function state.validate()
         enabled = { latex.enabled, 'boolean' },
         converter = { latex.converter, 'string' },
         highlight = { latex.highlight, 'string' },
+        lines_above = { latex.lines_above, 'integer' },
+        lines_below = { latex.lines_below, 'integer' },
     })
 
     local heading = config.heading

--- a/lua/render-markdown/types.lua
+++ b/lua/render-markdown/types.lua
@@ -72,6 +72,8 @@
 ---@field public enabled boolean
 ---@field public converter string
 ---@field public highlight string
+---@field public lines_above integer
+---@field public lines_below integer
 
 ---@class render.md.AntiConceal
 ---@field public enabled boolean


### PR DESCRIPTION
Improved $\LaTeX$ compatibility for more advanced converters like [libtexprintf](https://github.com/bartp5/libtexprintf).

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/1d0432a1-da03-481a-afe2-373371ca5659" width=500><br></td>
    <td><img src="https://github.com/user-attachments/assets/de25b606-96e4-4dc2-96e4-92d60007a797" width=500><br>
</details></td>
  </tr>
</table>

<details>
  <summary>Step by step</summary>
  latex2text converter:<br>
  <img src="https://github.com/user-attachments/assets/1d0432a1-da03-481a-afe2-373371ca5659" width=500><br>
  
  [utftex](https://github.com/bartp5/libtexprintf) converter:
  <img src="https://github.com/user-attachments/assets/65d7686f-f362-4106-a706-35f55fad73ff" width=500><br>
  
  Initial compatibility fix:
  <img src="https://github.com/user-attachments/assets/bed7f79b-9b40-423b-990d-231eb9626ebd" width=500><br>
  
  Removed trailing whitespace:
  <img src="https://github.com/user-attachments/assets/fb915b96-7f1d-4e73-874e-3e7006421dbe" width=500><br>
  
  Variables for lines above and below $\LaTeX$ blocks (both set to 1):
  <img src="https://github.com/user-attachments/assets/de25b606-96e4-4dc2-96e4-92d60007a797" width=500><br>
</details>