### PR TITLE
✨feat(`dash.width`): New option added.

### DIFF
--- a/lua/render-markdown/handler/markdown.lua
+++ b/lua/render-markdown/handler/markdown.lua
@@ -145,7 +145,7 @@ M.render_dash = function(buf, info)
         start_row = info.start_row,
         start_col = 0,
         opts = {
-            virt_text = { { dash.icon:rep(util.get_width(buf)), dash.highlight } },
+            virt_text = { { dash.icon:rep(dash.width), dash.highlight } },
             virt_text_pos = 'overlay',
         },
     }

--- a/lua/render-markdown/init.lua
+++ b/lua/render-markdown/init.lua
@@ -1,6 +1,7 @@
 local colors = require('render-markdown.colors')
 local manager = require('render-markdown.manager')
 local state = require('render-markdown.state')
+local util = require('render-markdown.util')
 
 ---@class render.md.Init
 local M = {}
@@ -270,8 +271,11 @@ M.default_config = {
         -- Replaces '---'|'***'|'___'|'* * *' of 'thematic_break'
         -- The icon gets repeated across the window's width
         icon = '─',
+        -- Number of times to repeat 'icon'.
+        width = util.get_width(vim.api.nvim_get_current_buf()),
         -- Highlight for the whole line generated from the icon
         highlight = 'RenderMarkdownDash',
+
     },
     bullet = {
         -- Turn on / off list bullet rendering

--- a/lua/render-markdown/state.lua
+++ b/lua/render-markdown/state.lua
@@ -134,6 +134,7 @@ function state.validate()
         enabled = { dash.enabled, 'boolean' },
         icon = { dash.icon, 'string' },
         highlight = { dash.highlight, 'string' },
+        width = { dash.width, 'number' },
     })
 
     local bullet = config.bullet

--- a/lua/render-markdown/types.lua
+++ b/lua/render-markdown/types.lua
@@ -47,6 +47,7 @@
 ---@class render.md.BasicComponent
 ---@field public enabled boolean
 ---@field public icon string
+---@field public width number
 ---@field public highlight string
 
 ---@class render.md.Code


### PR DESCRIPTION
Users can now do 
```lua
dash = {
  icon = '─',
  width = 79
},
```

![screenshot_2024-07-24_18-45-13_296783475](https://github.com/user-attachments/assets/b7d7139c-19ee-4d3b-87c0-295f56be37e4)

To limit the width of dash. This is cool for users using `vim.opt.colorcolumn` to improve readability.