### PR TITLE
✨feat(`heading.background_eol`): New option added.

### DIFF
--- a/lua/render-markdown/handler/markdown.lua
+++ b/lua/render-markdown/handler/markdown.lua
@@ -80,7 +80,7 @@ M.render_heading = function(buf, info)
             end_row = info.end_row + 1,
             end_col = 0,
             hl_group = background,
-            hl_eol = true,
+            hl_eol = heading.background_eol,
         },
     }
     list.add(marks, background_mark)

--- a/lua/render-markdown/init.lua
+++ b/lua/render-markdown/init.lua
@@ -82,6 +82,7 @@ local M = {}
 ---@field public sign? boolean
 ---@field public icons? string[]
 ---@field public signs? string[]
+---@field public background_eol? boolean
 ---@field public backgrounds? string[]
 ---@field public foregrounds? string[]
 
@@ -212,6 +213,9 @@ M.default_config = {
         -- Added to the sign column if enabled
         -- The 'level' is used to index into the array using a cycle
         signs = { '󰫎 ' },
+        -- Background highlights render until the end of the line if true.
+        -- Or until the end of the text if false.
+        background_eol = true,
         -- The 'level' is used to index into the array using a clamp
         -- Highlight for the heading icon and extends through the entire line
         backgrounds = {

--- a/lua/render-markdown/types.lua
+++ b/lua/render-markdown/types.lua
@@ -67,6 +67,7 @@
 ---@field public sign boolean
 ---@field public icons string[]
 ---@field public signs string[]
+---@field public background_eol boolean
 ---@field public backgrounds string[]
 ---@field public foregrounds string[]
 


### PR DESCRIPTION
The new option
```lua
heading = {
  background_eol = false
}
```

When set to false, it allow rendering the background until the `end of the text`, instead of until the `end of the line`:

![screenshot_2024-07-24_21-24-52_639052097](https://github.com/user-attachments/assets/a93bf53e-46d5-4b44-aa9c-437aa8f2e567)

Which again, it's really nice for people using `vim.opt.colorcolumn`.