### PR TITLE
fix: `block` code rendering with transparent background

### DIFF
--- a/lua/render-markdown/handler/markdown.lua
+++ b/lua/render-markdown/handler/markdown.lua
@@ -257,7 +257,7 @@ function M.render_code(buf, info)
                 start_col = 0,
                 opts = {
                     priority = 0,
-                    hl_mode = 'combine',
+                    hl_mode = 'replace',
                     virt_text = { { pad, 'Normal' } },
                     virt_text_win_col = width,
                 },


### PR DESCRIPTION
Hello @MeanderingProgrammer! 🙂 

First off, congrats on v5.0.0! Lots of great new features to play with!

Here is the fix for the issue described in #73 observed when using a transparent background. 

Before:
![image](https://github.com/user-attachments/assets/26579697-9228-4327-9bdf-4e5480602660)

After:
![image](https://github.com/user-attachments/assets/c06dd2ec-6282-4a7b-936c-a689e14199dc)

This was due to passing in the `hl_mode = 'combine'` option. 

From the docs:
> hl_mode : control how highlights are combined with the highlights of the text. Currently only affects virt_text highlights, but might affect `hl_group` in later versions.
> - "replace": only show the virt_text color. This is the default.
> - "combine": combine with background text color.
> - "blend": blend with background text color. Not supported for "inline" virt_text.

I've only tested this for a transparent background, but I'm 99% sure this will work the same way for solid backgrounds as well. 